### PR TITLE
Fix to handle hex numeric XML entities

### DIFF
--- a/slaxml.lua
+++ b/slaxml.lua
@@ -54,7 +54,7 @@ function SLAXML:parse(xml,options)
 	local nsStack = {}
 
 	local entityMap  = { ["lt"]="<", ["gt"]=">", ["amp"]="&", ["quot"]='"', ["apos"]="'" }
-	local entitySwap = function(orig,n,s) return entityMap[s] or n=="#" and char(s) or orig end
+	local entitySwap = function(orig,n,s) return entityMap[s] or n=="#" and char('0'..s) or orig end  
 	local function unescape(str) return gsub( str, '(&(#?)([%d%a]+);)', entitySwap ) end
 	local anyElement = false
 


### PR DESCRIPTION
If the parser encounters a hex entity, eg `&#xA;`, `entitySwap` correctly
identifies it as a numeric entity but causes a 'bad argument' error as
Lua requires hex numbers to be prefixed with "0x", i.e. 0xA not xA

By prepending "0" to the numeric portion of the entity, hex values are
correctly formed and decimal values are still valid, e.g. 0xA & 010
