### PR TITLE
Added basic rockspec

### DIFF
--- a/slaxml-0.7-0.rockspec
+++ b/slaxml-0.7-0.rockspec
@@ -1,0 +1,27 @@
+package = "SLAXML"
+version = "0.7-0"
+source = {
+  url = "https://github.com/Phrogz/SLAXML.git"
+}
+description = {
+  summary = "SAX-like streaming XML parser for Lua",
+  detailed = [[
+      SLAXML is a pure-Lua SAX-like streaming XML parser. It is more robust than many (simpler) pattern-based parsers that exist (such as http://phrogz.net/lua/AKLOMParser.lua), properly supporting code like <expr test="5 > 7" />, CDATA nodes, comments, namespaces, and processing instructions.
+
+      It is currently not a truly valid XML parser, however, as it allows certain XML that is syntactically-invalid (not well-formed) to be parsed without reporting an error.
+    ]],
+  homepage = "https://github.com/Phrogz/SLAXML",
+  maintainer = "Gavin Kistner <avin@phrogz.net>",
+  license = "MIT"
+}
+dependencies = {
+  "lua ~> 5.1",
+}
+build = {
+  type = "builtin",
+
+  modules = {
+    ["slaxml"] = "slaxml.lua",
+    ["slaxdom"] = "slaxdom.lua"
+  }
+}


### PR DESCRIPTION
I've added a basic rockspec that can be submitted to luarocks.org. Tested locally with "luarocks make", both slaxml and slaxdom modules were available and the functions worked. Would you mind submitting this to luarocks.org so SLAXML could be used as a dependency instead of having to embed it?