### PR TITLE
Fix git tag in rockspec

### DIFF
--- a/slaxml-0.8-1.rockspec
+++ b/slaxml-0.8-1.rockspec
@@ -2,7 +2,7 @@ package = "SLAXML"
 version = "0.8-1"
 source = {
   url = "git://github.com/Phrogz/SLAXML",
-  tag = "v0.8.1"
+  tag = "v0.8"
 }
 description = {
   summary = "SAX-like streaming XML parser for Lua",


### PR DESCRIPTION
Current rockspec does not work with Luarocks because there is no "v0.8.1" tag in the repository.

To fix this either replace the tag specified in the rockspec (this PR does this), or add a "v0.8.1" tag to the repository to retrospectively make the rockspec correct.

---

Side note:

I think you may be misunderstanding how versioning works in luarocks, the `-` is supposed to separate the version of the package from the revision of the rockspec itself (see **version** in https://github.com/luarocks/luarocks/wiki/Rockspec-format#package-metadata).

So say if you're preparing to release v0.8.1 of your library - the rockspec version should read `0.8.1-1` as its the `1`st revision of the rockspec file for the package version `0.8.1`.

By the same logic rockspec version `0.8-1` should correspond to the `1`st rockspec file revision of package version `0.8` - so should probably use the tag `v0.8`.